### PR TITLE
Implement RevenueCat product listing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Create a `.env.local` file and set the following variable:
 
 ```env
 CLAUDE_API_KEY=your_claude_api_key_here
+REVENUECAT_API_KEY=your_revenuecat_api_key_here
+REVENUECAT_PROJECT_ID=your_revenuecat_project_id
 ```
 
 ## Deployment

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+
+let cachedProducts: any[] | null = null;
+let cacheTimestamp = 0;
+const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
+
+export async function GET() {
+  if (cachedProducts && Date.now() - cacheTimestamp < CACHE_DURATION) {
+    return NextResponse.json({ products: cachedProducts });
+  }
+
+  const apiKey = process.env.REVENUECAT_API_KEY;
+  const projectId = process.env.REVENUECAT_PROJECT_ID;
+
+  if (!apiKey || !projectId) {
+    return NextResponse.json(
+      { error: "RevenueCat API not configured" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.revenuecat.com/v1/projects/${projectId}/products`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("RevenueCat API Error:", errorText);
+      return NextResponse.json(
+        { error: "Failed to fetch products" },
+        { status: 500 }
+      );
+    }
+
+    const data = await response.json();
+    cachedProducts = data.products ?? [];
+    cacheTimestamp = Date.now();
+
+    return NextResponse.json({ products: cachedProducts });
+  } catch (error) {
+    console.error("Products API Error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch products" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -65,6 +65,9 @@ export const ERROR_MESSAGES = {
     poemGenerationFailed: "Failed to generate poem",
     serverError: "Server error",
   },
+  subscription: {
+    fetchFailed: "Failed to fetch subscription products",
+  },
 } as const;
 
 // 공유 관련

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { SubscriptionProduct } from "@/types";
+import { getProducts } from "@/lib/getProducts";
+import { ERROR_MESSAGES } from "@/constants";
+
+/**
+ * Hook to load subscription products with session storage caching
+ */
+export function useProducts() {
+  const [products, setProducts] = useState<SubscriptionProduct[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const cacheKey = "subscriptionProducts";
+    const cached = sessionStorage.getItem(cacheKey);
+    if (cached) {
+      setProducts(JSON.parse(cached));
+      return;
+    }
+
+    getProducts()
+      .then((items) => {
+        setProducts(items);
+        sessionStorage.setItem(cacheKey, JSON.stringify(items));
+      })
+      .catch((err) => {
+        console.error(err);
+        setError(ERROR_MESSAGES.subscription.fetchFailed);
+      });
+  }, []);
+
+  return { products, error };
+}

--- a/src/lib/getProducts.ts
+++ b/src/lib/getProducts.ts
@@ -1,0 +1,18 @@
+import { SubscriptionProduct } from "@/types";
+
+/**
+ * Fetch subscription products from the API
+ */
+export async function getProducts(): Promise<SubscriptionProduct[]> {
+  try {
+    const response = await fetch("/api/products");
+    if (!response.ok) {
+      throw new Error("Failed to fetch products");
+    }
+    const data = await response.json();
+    return data.products as SubscriptionProduct[];
+  } catch (error) {
+    console.error("Failed to load products:", error);
+    return [];
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,3 +41,11 @@ export interface PoemStructuredData {
   inLanguage: string;
   creativeWorkStatus: string;
 }
+
+export interface SubscriptionProduct {
+  identifier: string;
+  price: number;
+  priceString: string;
+  description: string;
+  title: string;
+}


### PR DESCRIPTION
## Summary
- add new `/api/products` route to proxy RevenueCat and cache results
- add client hook `useProducts` and helper `getProducts`
- document new RevenueCat env vars
- add related types and constants

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cda27429c8326a94baa4f1adf5697